### PR TITLE
Refactor red envelope algorithm

### DIFF
--- a/bot/modules/extra/red_envelope.py
+++ b/bot/modules/extra/red_envelope.py
@@ -205,8 +205,8 @@ async def pick_red_bag(_, call):
         if call.from_user.id in bag["flag"]: return await callAnswer(call, 'ʕ•̫͡•ʔ 你已经领取过红包了。不许贪吃', True)
 
         if bag["rest"] > 1:
-            k = bag["m"] - 1 * (bag["members"] - bag["n"] - 1)
-            t = math.ceil(random.uniform(1, k / 2))  # 对每个红包的上限进行动态限制
+            k = 2 * bag["m"] / (bag["members"] - bag["n"])
+            t = math.ceil(random.uniform(1, k ))  # 对每个红包的上限进行动态限制
 
         elif bag["rest"] == 1:
             t = bag["m"]


### PR DESCRIPTION
原算法下，在多次抢红包实践中发现后抢的大多为1。
故参考网络中流传的微信抢红包原理，让每人抢到红包金额的期望大致相等的
在总额100、人数10的条件下，经10000次模拟分配
原算法均值：
avg: [23.6907, 17.9181, 14.0032, 10.6132, 8.2364, 6.395, 5.0614, 4.0052, 3.2772, 6.7996]
改进后算法：
avg: [11.0193, 10.8102, 10.836, 10.6382, 10.4489, 10.2453, 9.9658, 9.7721, 9.0006, 7.2636]